### PR TITLE
Upgrade to alpine:3.8 to fix CVE-2019-5021

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.4
+FROM alpine:3.8
 
 ENV FREERADIUS_VERSION=v3.0.x
 


### PR DESCRIPTION
This Dockerfile is vulnerable to [CVE-2019-5021](https://alpinelinux.org/posts/Docker-image-vulnerability-CVE-2019-5021.html) as it inherits from Alpine version 3.4 and installs the `linux-pam` package.

Upgrading to `alpine:3.8` mitigates this vulnerability.